### PR TITLE
Feature/improving drawing performance

### DIFF
--- a/GameOfHive/Animations.swift
+++ b/GameOfHive/Animations.swift
@@ -8,82 +8,170 @@
 
 import UIKit
 
-protocol ScaleAnimationDelegate: class {
+private protocol AnimationDelegate: class {
     func animationDidFinish(animation: ScaleAnimation)
 }
 
-func == (lhs: ScaleAnimation, rhs: ScaleAnimation) -> Bool {
-    return lhs.view == rhs.view
+enum AnimationState {
+    case Ready
+    case Animating(identifier: Int)
+    
+    var identifier: Int? {
+        switch self {
+        case .Ready:
+            return nil
+        case .Animating(let identifier):
+            return identifier
+        }
+    }
 }
 
-class ScaleAnimation: Equatable {
-    unowned var view: HexagonView
-    weak var delegate: ScaleAnimationDelegate?
+struct AnimationConfiguration {
+    let startValue: CGFloat
+    let endValue: CGFloat
+    let duration: CFTimeInterval
     
+    var delta: CGFloat {
+        return endValue - startValue
+    }
+}
+
+private class ScaleAnimation {
+    static var identifier : Int = 0
+    let identifier: Int
+    var views = Set<HexagonView>()
+    weak var delegate: AnimationDelegate?
+    
+    // values
     let start: CGFloat
     let delta: CGFloat
+    var currentValue: CGFloat = 0
     
+    // time
     let endTime: CFTimeInterval
-    var currentTime: CFTimeInterval = 0.0
+    var currentTime: CFTimeInterval = 0
     
-    init (view: HexagonView, end: CGFloat, time: CFTimeInterval) {
-        self.view = view
-        start = view.hunnyScaleFactor
-        delta = end - start
-        self.endTime = time
+    init (views: [HexagonView], configuration:AnimationConfiguration) {
+        self.identifier = ++ScaleAnimation.identifier
+        self.views = Set(views)
+        self.start = configuration.startValue
+        self.delta = configuration.delta
+        self.endTime = configuration.duration
+        
+        // set state to animating
+        views.map { $0.animationState = .Animating(identifier: self.identifier) }
     }
     
-    func increaseTime(time: CFTimeInterval) {
-        currentTime += time
-        if currentTime > self.endTime {
-            currentTime = self.endTime
+    private func increaseTime(increment: CFTimeInterval) {
+        currentTime += increment
+        
+        // clip to endtime
+        if currentTime > endTime {
+            currentTime = endTime
         }
         
-        let factor = CGFloat(currentTime / self.endTime)
-        let scale = start + delta * factor
+        // calculate current value
+        let factor = CGFloat(currentTime / endTime)
+        currentValue = start + delta * factor
         
-        view.hunnyScaleFactor = scale
-        view.setNeedsDisplay()
+        // create transform
+        let size = HexagonView.size
+        let height = size.height
+        let width = size.width
+        let tx = (width - (width * currentValue)) / 2
+        let ty = (height - (height * currentValue)) / 2
+        let translationTransform = CGAffineTransformMakeTranslation(tx, ty)
+        let scaleTransform = CGAffineTransformMakeScale(currentValue, currentValue)
+        var totalTransform = CGAffineTransformConcat(scaleTransform, translationTransform)
+        let path = CGPathCreateCopyByTransformingPath(HexagonView.pathPrototype, &totalTransform)
+
+        // draw fill
+        for view in views {
+            view.fillPath = path
+            view.setNeedsDisplay()
+        }
         
-        if currentTime >= self.endTime {
+        // finish if end time is reached
+        if currentTime >= endTime {
+            // reset animation state to .Ready
+            for view in views {
+                view.animationState = .Ready
+            }
+            
+            // inform delegate
             delegate?.animationDidFinish(self)
         }
     }
 }
 
-@objc class Animator: ScaleAnimationDelegate {
-    
-    static let animator = Animator()
-    
-    var displayLink: CADisplayLink! = nil
-    var animations: [ScaleAnimation] = []
-    var lastDrawTime: CFTimeInterval = 0
+@objc class Animator {
+    private static let animator = Animator()
+    private var displayLink: CADisplayLink!
+    private var animations: [Int : ScaleAnimation] = [:]
+    private var lastDrawTime: CFTimeInterval = 0
     
     init () {
         displayLink = UIScreen.mainScreen().displayLinkWithTarget(self, selector: Selector("tick:"))
         displayLink.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSDefaultRunLoopMode)
     }
-    
-    func addAnimationForView(view: HexagonView, end: CGFloat) {
-        var animation = ScaleAnimation(view: view, end: end, time: 0.4)
-        animation.delegate = self
-        animations.append(animation)
+        
+    static func addAnimationForViews(views: [HexagonView], configuration: AnimationConfiguration) {
+        // split by animation state
+        var ready: [HexagonView] = []
+        var animating: [HexagonView] = []
+        
+        for view in views {
+            switch view.animationState {
+            case .Ready:
+                ready.append(view)
+            case .Animating(let identifier):
+                animating.append(view)
+            }
+        }
+        
+        // start animating the .Ready views together in one animation
+        if ready.count > 0 {
+            let animation = ScaleAnimation(views: ready, configuration: configuration)
+            animation.delegate = animator
+            animator.animations[animation.identifier] = animation
+        }
+        
+        // pick up from animation value when already .Animating. create separate animations
+        for view in animating {
+            if let identifier = view.animationState.identifier, let existingAnimation = animator.animations[identifier] {
+                // remove view from old animation, if old animation becomes empty remove it entirely
+                existingAnimation.views.remove(view)
+                if existingAnimation.views.count == 0 {
+                    animator.animations[identifier] = nil
+                }
+                
+                // add to new animation starting from current value
+                let config = AnimationConfiguration(startValue: existingAnimation.currentValue, endValue: configuration.endValue, duration: configuration.duration)
+                let newAnimation = ScaleAnimation(views: [view], configuration: config)
+                newAnimation.delegate = animator
+                animator.animations[newAnimation.identifier] = newAnimation
+            }
+        }
     }
     
+    // display link
     func tick(displayLink: CADisplayLink) {
         if lastDrawTime == 0 {
             lastDrawTime = displayLink.timestamp
         }
+        
         let duration = displayLink.timestamp - lastDrawTime
-        for animation in animations {
+        
+        for (_, animation) in animations {
             animation.increaseTime(duration)
         }
+        
         lastDrawTime = displayLink.timestamp
     }
-    
-    func animationDidFinish(animation: ScaleAnimation) {
-        if let index = find(animations, animation) {
-            animations.removeAtIndex(index)
-        }
+}
+
+extension Animator: AnimationDelegate {
+    private func animationDidFinish(animation: ScaleAnimation) {
+        animations[animation.identifier] = nil
     }
 }

--- a/GameOfHive/Animations.swift
+++ b/GameOfHive/Animations.swift
@@ -14,7 +14,7 @@ private protocol AnimationDelegate: class {
 
 enum AnimationState {
     case Ready
-    case Animating(identifier: Int)
+    case Animating(identifier: UInt32)
 }
 
 struct AnimationConfiguration {
@@ -29,8 +29,13 @@ struct AnimationConfiguration {
 
 // MARK: Animation
 private class ScaleAnimation {
-    static var identifier : Int = 0
-    let identifier: Int
+    static var identifier : UInt32 = 0
+    static func nextIdentifier() -> UInt32 {
+        identifier = (identifier % UINT32_MAX) + 1
+        return identifier
+    }
+    
+    let identifier: UInt32
     var views = Set<HexagonView>()
     weak var delegate: AnimationDelegate?
     
@@ -44,7 +49,7 @@ private class ScaleAnimation {
     var currentTime: CFTimeInterval = 0
     
     init (views: [HexagonView], configuration:AnimationConfiguration) {
-        self.identifier = ++ScaleAnimation.identifier
+        self.identifier = ScaleAnimation.nextIdentifier()
         self.views = Set(views)
         self.start = configuration.startValue
         self.delta = configuration.delta
@@ -108,7 +113,7 @@ private class ScaleAnimation {
 @objc class Animator {
     private static let animator = Animator()
     private var displayLink: CADisplayLink!
-    private var animations: [Int : ScaleAnimation] = [:]
+    private var animations: [UInt32 : ScaleAnimation] = [:]
     private var lastDrawTime: CFTimeInterval = 0
     
     init () {

--- a/GameOfHive/Animations.swift
+++ b/GameOfHive/Animations.swift
@@ -27,6 +27,7 @@ struct AnimationConfiguration {
     }
 }
 
+// MARK: Animation
 private class ScaleAnimation {
     static var identifier : Int = 0
     let identifier: Int
@@ -102,6 +103,7 @@ private class ScaleAnimation {
     }
 }
 
+// MARK: Animator
 @objc class Animator {
     private static let animator = Animator()
     private var displayLink: CADisplayLink!
@@ -112,7 +114,8 @@ private class ScaleAnimation {
         displayLink = UIScreen.mainScreen().displayLinkWithTarget(self, selector: Selector("tick:"))
         displayLink.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSDefaultRunLoopMode)
     }
-        
+    
+    // MARK: Add
     static func addAnimationForViews(views: [HexagonView], configuration: AnimationConfiguration) {
         // split by animation state
         var ready: [HexagonView] = []
@@ -136,7 +139,7 @@ private class ScaleAnimation {
             }
         }
         
-        // start animating the .Ready views together in one animation
+        // Start animating the views with animation state ready together in a single animation
         if ready.count > 0 {
             let animation = ScaleAnimation(views: ready, configuration: configuration)
             animation.delegate = animator
@@ -144,7 +147,7 @@ private class ScaleAnimation {
         }
     }
     
-    // display link
+    // MARK: Display link
     func tick(displayLink: CADisplayLink) {
         if lastDrawTime == 0 {
             lastDrawTime = displayLink.timestamp
@@ -160,6 +163,7 @@ private class ScaleAnimation {
     }
 }
 
+// MARK: AnimationDelegate
 extension Animator: AnimationDelegate {
     private func animationDidFinish(animation: ScaleAnimation) {
         animations[animation.identifier] = nil

--- a/GameOfHive/Animations.swift
+++ b/GameOfHive/Animations.swift
@@ -67,7 +67,7 @@ private class ScaleAnimation {
         }
     }
     
-    private func increaseTime(increment: CFTimeInterval) {
+    func increaseTime(increment: CFTimeInterval) {
         currentTime += increment
         
         // clip to endtime

--- a/GameOfHive/Animations.swift
+++ b/GameOfHive/Animations.swift
@@ -117,10 +117,8 @@ private class ScaleAnimation {
     
     // MARK: Add
     static func addAnimationForViews(views: [HexagonView], configuration: AnimationConfiguration) {
-        // split by animation state
+        // collect views ready for animation
         var ready: [HexagonView] = []
-        var animating: [HexagonView] = []
-        
         for view in views {
             switch view.animationState {
             case .Ready:

--- a/GameOfHive/Animations.swift
+++ b/GameOfHive/Animations.swift
@@ -53,6 +53,13 @@ private class ScaleAnimation {
         views.map { $0.animationState = .Animating(identifier: self.identifier) }
     }
     
+    func removeView(view: HexagonView) {
+        views.remove(view)
+        if views.count == 0 {
+           delegate?.animationDidFinish(self)
+        }
+    }
+    
     private func increaseTime(increment: CFTimeInterval) {
         currentTime += increment
         
@@ -118,12 +125,8 @@ private class ScaleAnimation {
             case .Animating(let identifier):
                 // pick up from current animation value when already .Animating. creates separate animations per view
                 if let existingAnimation = animator.animations[identifier] {
-                    // remove view from old animation, if old animation becomes empty remove it entirely
-                    existingAnimation.views.remove(view)
-                    if existingAnimation.views.count == 0 {
-                        animator.animations[identifier] = nil
-                    }
-                    
+                    // remove view from old animation
+                    existingAnimation.removeView(view)
                     // add to new animation starting from current value
                     let config = AnimationConfiguration(startValue: existingAnimation.currentValue, endValue: configuration.endValue, duration: configuration.duration)
                     let newAnimation = ScaleAnimation(views: [view], configuration: config)

--- a/GameOfHive/Animations.swift
+++ b/GameOfHive/Animations.swift
@@ -137,8 +137,7 @@ private class ScaleAnimation {
                     // add to new animation starting from current value
                     let config = AnimationConfiguration(startValue: existingAnimation.currentValue, endValue: configuration.endValue, duration: configuration.duration)
                     let newAnimation = ScaleAnimation(views: [view], configuration: config)
-                    newAnimation.delegate = animator
-                    animator.animations[newAnimation.identifier] = newAnimation
+                    animator.addAnimation(newAnimation)
                 }
             }
         }
@@ -146,9 +145,13 @@ private class ScaleAnimation {
         // Start animating the views with animation state ready together in a single animation
         if ready.count > 0 {
             let animation = ScaleAnimation(views: ready, configuration: configuration)
-            animation.delegate = animator
-            animator.animations[animation.identifier] = animation
+            animator.addAnimation(animation)
         }
+    }
+    
+    private func addAnimation(animation: ScaleAnimation) {
+        animation.delegate = self
+        animations[animation.identifier] = animation
     }
     
     // MARK: Display link

--- a/GameOfHive/Animations.swift
+++ b/GameOfHive/Animations.swift
@@ -139,6 +139,11 @@ private class ScaleAnimation {
                     let newAnimation = ScaleAnimation(views: [view], configuration: config)
                     animator.addAnimation(newAnimation)
                 }
+                else {
+                    assert(false, "Should not occur")
+                    view.animationState = .Ready
+                    ready.append(view)
+                }
             }
         }
         

--- a/GameOfHive/Animations.swift
+++ b/GameOfHive/Animations.swift
@@ -55,6 +55,7 @@ private class ScaleAnimation {
     }
     
     func removeView(view: HexagonView) {
+        view.animationState = .Ready
         views.remove(view)
         if views.count == 0 {
            delegate?.animationDidFinish(self)

--- a/GameOfHive/HexagonView.swift
+++ b/GameOfHive/HexagonView.swift
@@ -16,9 +16,11 @@ class HexagonView: UIView {
     static var edgePath: CGMutablePathRef? = nil
     static var lineWidth: CGFloat = 1.0
     
-    static func updateEdgePath(width: CGFloat, height: CGFloat, lineWidth: CGFloat) {
+    static func updateEdgePath(size: CGSize, lineWidth: CGFloat) {
         self.lineWidth = lineWidth
         
+        let height = size.height
+        let width = size.width
         let s = height / 2.0
         let b = width / 2.0
         let a = (height - s) / 2.0

--- a/GameOfHive/HexagonView.swift
+++ b/GameOfHive/HexagonView.swift
@@ -8,16 +8,19 @@
 
 import UIKit
 
-protocol HexagonViewDelegate {
-    func userDidUpateCellAtCoordinate(coordinate: Coordinate, alive:Bool)
+protocol HexagonViewDelegate: class {
+    func userDidUpateCell(cell: HexagonView)
 }
 
 class HexagonView: UIView {
-    static var edgePath: CGMutablePathRef? = nil
+    static var pathPrototype: CGMutablePathRef!
+    static var size: CGSize!
     static var lineWidth: CGFloat = 1.0
+    static let fillColor = UIColor.lightAmberColor
     
     static func updateEdgePath(size: CGSize, lineWidth: CGFloat) {
         self.lineWidth = lineWidth
+        self.size = size
         
         let height = size.height
         let width = size.width
@@ -27,30 +30,24 @@ class HexagonView: UIView {
         
         let halfLineWidth = lineWidth / 2.0
         
-        let edge = CGPathCreateMutable()
-        CGPathMoveToPoint(edge, nil, b, halfLineWidth)
-        CGPathAddLineToPoint(edge, nil, width - halfLineWidth, a)
-        CGPathAddLineToPoint(edge, nil, width - halfLineWidth, a + s)
-        CGPathAddLineToPoint(edge, nil, b, height - halfLineWidth)
-        CGPathAddLineToPoint(edge, nil, halfLineWidth, a + s)
-        CGPathAddLineToPoint(edge, nil, halfLineWidth, a)
-        CGPathAddLineToPoint(edge, nil, b, halfLineWidth)
-        
-        edgePath = edge
+        let path = CGPathCreateMutable()
+        CGPathMoveToPoint(path, nil, b, halfLineWidth)
+        CGPathAddLineToPoint(path, nil, width - halfLineWidth, a)
+        CGPathAddLineToPoint(path, nil, width - halfLineWidth, a + s)
+        CGPathAddLineToPoint(path, nil, b, height - halfLineWidth)
+        CGPathAddLineToPoint(path, nil, halfLineWidth, a + s)
+        CGPathAddLineToPoint(path, nil, halfLineWidth, a)
+        CGPathAddLineToPoint(path, nil, b, halfLineWidth)
+        pathPrototype = path
     }
     
     var coordinate = Coordinate(row: NSNotFound, column: NSNotFound)
-    var alive: Bool = true {
-        didSet {
-            if alive != oldValue {
-                let end: CGFloat = alive ? 1.0 : 0.0
-                Animator.animator.addAnimationForView(self, end: end)
-            }
-        }
-    }
+    var alive: Bool = false
+
+    var animationState: AnimationState = .Ready
+    var fillPath: CGPathRef!
   
-    var hexagonViewDelegate: HexagonViewDelegate?
-    var hunnyScaleFactor: CGFloat = 1.0
+    weak var hexagonViewDelegate: HexagonViewDelegate?
   
     required init(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
@@ -64,47 +61,19 @@ class HexagonView: UIView {
     override func touchesBegan(touches: Set<NSObject>, withEvent event: UIEvent) {
         super.touchesBegan(touches, withEvent: event)
         self.alive = !self.alive
-        self.setNeedsDisplay()
-        hexagonViewDelegate?.userDidUpateCellAtCoordinate(coordinate, alive: alive)
+        // inform delegate
+        hexagonViewDelegate?.userDidUpateCell(self)
     }
     
     override func drawRect(rect: CGRect) {
+        if fillPath == nil {
+            return;
+        }
+        
         let context = UIGraphicsGetCurrentContext()
-        
-        let strokeColor = UIColor.darkAmberColor
-        let hunnyColor = UIColor.lightAmberColor
-
-        // edge
-        let lineWidth = HexagonView.lineWidth
-        let edgePath = HexagonView.edgePath
-        
-        // hunny transform
-        let height = rect.height
-        let width = rect.width
-        let tx = (width - (width * hunnyScaleFactor)) / 2
-        let ty = (height - (height * hunnyScaleFactor)) / 2
-        let hunnyTranslate = CGAffineTransformMakeTranslation(tx, ty)
-        let hunnyScale = CGAffineTransformMakeScale(hunnyScaleFactor, hunnyScaleFactor)
-        var hunnyTransform = CGAffineTransformConcat(hunnyScale, hunnyTranslate)
-        
-        //hunny path
-        let hunny = CGPathCreateCopyByTransformingPath(edgePath, &hunnyTransform)
-
-        // hunny
-        CGContextSaveGState(context)
-        CGContextSetLineWidth(context, lineWidth)
-        CGContextSetFillColorWithColor(context, hunnyColor.CGColor)
-        CGContextAddPath(context, hunny)
+        CGContextSetLineWidth(context, HexagonView.lineWidth)
+        CGContextSetFillColorWithColor(context, HexagonView.fillColor.CGColor)
+        CGContextAddPath(context, fillPath)
         CGContextFillPath(context)
-        CGContextRestoreGState(context)
-        
-//        // edge
-//        CGContextSaveGState(context)
-//        CGContextAddPath(context, edgePath)
-//        CGContextSetLineWidth(context, lineWidth)
-//        CGContextSetStrokeColorWithColor(context, strokeColor.CGColor)
-//        CGContextStrokePath(context)
-//        CGContextRestoreGState(context)
-//        
     }
 }

--- a/GameOfHive/ViewController.swift
+++ b/GameOfHive/ViewController.swift
@@ -15,6 +15,7 @@ class ViewController: UIViewController, HexagonViewDelegate {
     var timer: NSTimer!
     var grid: HexagonGrid!
     var button: UIButton!
+    var cellSize: CGSize!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -35,6 +36,10 @@ class ViewController: UIViewController, HexagonViewDelegate {
         var cellHeight: CGFloat = (view.bounds.height / (CGFloat(numberOfRows-1)) * 1.5)
         let sideLength = cellHeight/2
         let cellWidth = CGFloat(sqrt(3.0)) * sideLength
+        
+        cellSize = CGSize(width: cellWidth, height: cellHeight)
+        HexagonView.updateEdgePath(cellSize, lineWidth: 3)
+
         numberOfColumns = Int(ceil(view.bounds.width / cellWidth))
         let xOffset: CGFloat = -cellWidth/2
         let yOffset = -(cellHeight/4 + sideLength)

--- a/GameOfHive/ViewController.swift
+++ b/GameOfHive/ViewController.swift
@@ -32,6 +32,7 @@ class ViewController: UIViewController, HexagonViewDelegate {
     
     // MARK: Grid
     func createGrid() {
+        assert(timer == nil, "Expect not running")
         assert(grid == nil, "Expect grid does not exist")
         
         let cellHeight: CGFloat = (view.bounds.height / (CGFloat(numberOfRows-1)) * 1.5)

--- a/GameOfHive/ViewController.swift
+++ b/GameOfHive/ViewController.swift
@@ -177,9 +177,14 @@ extension ViewController {
     
     override func motionEnded(motion: UIEventSubtype, withEvent event: UIEvent) {
         if motion == .MotionShake {
-            grid = emptyGrid(numberOfRows,numberOfColumns)
-            updateGrid()
             stop()
+            dispatch_async(gridQueue) {
+                let grid = emptyGrid(self.numberOfRows,self.numberOfColumns)
+                self.grid = grid
+                dispatch_async(dispatch_get_main_queue()) {
+                    self.drawGrid(grid)
+                }
+            }
         }
     }
 }

--- a/GameOfHive/ViewController.swift
+++ b/GameOfHive/ViewController.swift
@@ -18,7 +18,21 @@ class ViewController: UIViewController, HexagonViewDelegate {
     var timer: NSTimer!
     var grid: HexagonGrid!
     var button: UIButton!
+        
+    // MARK: UIViewController
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
     
+    override func prefersStatusBarHidden() -> Bool {
+        return true;
+    }
+    
+    override func preferredInterfaceOrientationForPresentation() -> UIInterfaceOrientation {
+        return .Portrait
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         createGrid()
@@ -135,19 +149,6 @@ class ViewController: UIViewController, HexagonViewDelegate {
         timer?.invalidate()
         timer = nil
         button.setImage(UIImage(named: "button_play"), forState: .Normal)
-    }
-    
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
-    }
-    
-    override func prefersStatusBarHidden() -> Bool {
-        return true;
-    }
-    
-    override func preferredInterfaceOrientationForPresentation() -> UIInterfaceOrientation {
-        return .Portrait
     }
 }
 

--- a/GameOfHive/ViewController.swift
+++ b/GameOfHive/ViewController.swift
@@ -30,20 +30,20 @@ class ViewController: UIViewController, HexagonViewDelegate {
         self.view.addSubview(button)
     }
     
+    // MARK: Grid
     func createGrid() {
+        assert(grid == nil, "Expect grid does not exist")
+        
         let cellHeight: CGFloat = (view.bounds.height / (CGFloat(numberOfRows-1)) * 1.5)
         let sideLength = cellHeight/2
         let cellWidth = CGFloat(sqrt(3.0)) * sideLength
         let cellSize = CGSize(width: cellWidth, height: cellHeight)
         HexagonView.updateEdgePath(cellSize, lineWidth: 3)
-
+        
         numberOfColumns = Int(ceil(view.bounds.width / cellWidth))
-        
-        dispatch_sync(gridQueue) {
-            self.grid = HexagonGrid(rows: self.numberOfRows, columns: self.numberOfColumns, initialGridType: .Random)
-        }
-        
-        let xOffset: CGFloat = -cellWidth/2
+        grid = HexagonGrid(rows: numberOfRows, columns: numberOfColumns, initialGridType: .Random)
+
+        let xOffset = -cellWidth/2
         let yOffset = -(cellHeight/4 + sideLength)
         
         for hexagon in grid {
@@ -105,7 +105,7 @@ class ViewController: UIViewController, HexagonViewDelegate {
     }
 
     
-    // Timer
+    // MARK: Timer
     func createTimer() -> NSTimer {
         return NSTimer.scheduledTimerWithTimeInterval(0.5, target: self, selector: Selector("tick:"), userInfo: nil, repeats: true)
     }
@@ -114,7 +114,7 @@ class ViewController: UIViewController, HexagonViewDelegate {
         updateGrid()
     }
     
-    // Button
+    // MARK: Button
     func toggle(button: UIButton) {
         if timer == nil {
             start()
@@ -150,7 +150,7 @@ class ViewController: UIViewController, HexagonViewDelegate {
     }
 }
 
-// HexagonView Delegate
+// MARK: HexagonView Delegate
 extension ViewController: HexagonViewDelegate {
     func userDidUpateCell(cell: HexagonView) {
         dispatch_async(gridQueue) {
@@ -169,7 +169,7 @@ extension ViewController: HexagonViewDelegate {
     }
 }
 
-// Shake
+// MARK: Shake
 extension ViewController {
     override func canBecomeFirstResponder() -> Bool {
         return true

--- a/GameOfHive/ViewController.swift
+++ b/GameOfHive/ViewController.swift
@@ -7,56 +7,55 @@
 //
 
 import UIKit
+   
+// queue enforcing serial grid creation
+let gridQueue = dispatch_queue_create("grid_queue", DISPATCH_QUEUE_SERIAL)
 
 class ViewController: UIViewController, HexagonViewDelegate {
-    var numberOfRows = 15
+    var numberOfRows = 50
     var numberOfColumns: Int!
     var cells: [HexagonView] = []
     var timer: NSTimer!
     var grid: HexagonGrid!
     var button: UIButton!
-    var cellSize: CGSize!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         createGrid()
+        
         button = UIButton.buttonWithType(.Custom) as! UIButton
         button.addTarget(self, action: Selector("toggle:"), forControlEvents: .TouchUpInside)
 		button.frame = CGRectMake(10, 10, 30, 30)
 		button.setImage(UIImage(named: "button_play"), forState: .Normal)
-
         self.view.addSubview(button)
     }
     
-    func createTimer() -> NSTimer {
-        return NSTimer.scheduledTimerWithTimeInterval(1, target: self, selector: Selector("tick:"), userInfo: nil, repeats: true)
-    }
-    
     func createGrid() {
-        var cellHeight: CGFloat = (view.bounds.height / (CGFloat(numberOfRows-1)) * 1.5)
+        let cellHeight: CGFloat = (view.bounds.height / (CGFloat(numberOfRows-1)) * 1.5)
         let sideLength = cellHeight/2
         let cellWidth = CGFloat(sqrt(3.0)) * sideLength
-        
-        cellSize = CGSize(width: cellWidth, height: cellHeight)
+        let cellSize = CGSize(width: cellWidth, height: cellHeight)
         HexagonView.updateEdgePath(cellSize, lineWidth: 3)
 
         numberOfColumns = Int(ceil(view.bounds.width / cellWidth))
+        
+        dispatch_sync(gridQueue) {
+            self.grid = HexagonGrid(rows: self.numberOfRows, columns: self.numberOfColumns, initialGridType: .Random)
+        }
+        
         let xOffset: CGFloat = -cellWidth/2
         let yOffset = -(cellHeight/4 + sideLength)
         
-        HexagonView.updateEdgePath(cellWidth, height: cellHeight, lineWidth: 2.0)
-      
-        grid = HexagonGrid(rows: numberOfRows, columns: numberOfColumns, initialGridType: .Random)
-        
-        for hex in grid {
-            let row = hex.location.row
-            let column = hex.location.column
+        for hexagon in grid {
+            let row = hexagon.location.row
+            let column = hexagon.location.column
             let x = xOffset + (row & 1 == 0 ? (cellWidth * CGFloat(column)) : (cellWidth * CGFloat(column)) + (cellWidth * 0.5))
             let y = yOffset + ((cellHeight - sideLength/2) * CGFloat(row))
             let frame = CGRect(x: x, y: y, width: cellWidth, height: cellHeight)
             let cell = HexagonView(frame: frame)
-            cell.coordinate = hex.location
-            cell.alive = hex.active
+            cell.coordinate = hexagon.location
+            cell.alive = hexagon.active
+            cell.fillPath = cell.alive ? HexagonView.pathPrototype : nil
             cell.hexagonViewDelegate = self
             cells.append(cell)
             view.addSubview(cell)
@@ -64,45 +63,58 @@ class ViewController: UIViewController, HexagonViewDelegate {
     }
     
     func updateGrid() {
-      
-      dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
-        self.grid = nextGrid(self.grid)
-        dispatch_async(dispatch_get_main_queue()) {
-          for cell in self.cells {
-            if let hexagon = self.grid.hexagon(atLocation: cell.coordinate) {
-              cell.alive = hexagon.active
-              cell.setNeedsDisplay()
+        dispatch_async(gridQueue) {
+            let grid = nextGrid(self.grid)
+            self.grid = grid
+            dispatch_async(dispatch_get_main_queue()) {
+                self.drawGrid(grid)
             }
-          }
         }
-      }
     }
     
-  
-    func cellWithCoordinate(coordinate: Coordinate, frame: CGRect) -> HexagonView {
-        let optionalCell = cells.filter { cell in
-            cell.coordinate == coordinate
-        }.first
+    func drawGrid(grid: HexagonGrid) {
+        assert(NSThread.isMainThread(), "Expect main thread")
         
-        if let cell = optionalCell {
-            cell.setNeedsDisplay()
-            return cell
+        // split cells by needed action. filter unchanged cells
+        var cellsToActivate: [HexagonView] = []
+        var cellsToDeactivate: [HexagonView] = []
+        
+        for cell in cells {
+            if let hexagon = grid.hexagon(atLocation: cell.coordinate) {
+                switch (cell.alive, hexagon.active) {
+                case (false, true):
+                    cellsToActivate.append(cell)
+                case (true, false):
+                    cellsToDeactivate.append(cell)
+                default:()
+                }
+                
+                cell.alive = hexagon.active
+            }
         }
         
-        let cell = HexagonView(frame: frame)
-        cells.append(cell)
-        view.addSubview(cell)
-        return cell
+        // animate changes
+        if cellsToActivate.count > 0 {
+            let config = AnimationConfiguration(startValue: 0, endValue: 1, duration: 0.4)
+            Animator.addAnimationForViews(cellsToActivate, configuration: config)
+        }
+        if cellsToDeactivate.count > 0 {
+            let config = AnimationConfiguration(startValue: 1, endValue: 0, duration: 0.2)
+            Animator.addAnimationForViews(cellsToDeactivate, configuration: config)
+        }
     }
-  
-    func userDidUpateCellAtCoordinate(coordinate: Coordinate, alive:Bool) {
-        grid = grid.setActive(alive, atLocation: coordinate)
+
+    
+    // Timer
+    func createTimer() -> NSTimer {
+        return NSTimer.scheduledTimerWithTimeInterval(0.5, target: self, selector: Selector("tick:"), userInfo: nil, repeats: true)
     }
-  
+    
     func tick(timer: NSTimer) {
         updateGrid()
     }
     
+    // Button
     func toggle(button: UIButton) {
         if timer == nil {
             start()
@@ -111,13 +123,10 @@ class ViewController: UIViewController, HexagonViewDelegate {
         }
     }
     
-    deinit {
-        stop()
-    }
-    
     func start() {
         timer?.invalidate()
         timer = createTimer()
+        timer.fire()
         button.setImage(UIImage(named: "button_stop"), forState: .Normal)
     }
     
@@ -131,28 +140,47 @@ class ViewController: UIViewController, HexagonViewDelegate {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
-  
+    
     override func prefersStatusBarHidden() -> Bool {
-      return true;
+        return true;
     }
-  
+    
     override func preferredInterfaceOrientationForPresentation() -> UIInterfaceOrientation {
-      return .Portrait
+        return .Portrait
     }
-  
-    /// pragma mark: Shake it baby
-  
+}
+
+// HexagonView Delegate
+extension ViewController: HexagonViewDelegate {
+    func userDidUpateCell(cell: HexagonView) {
+        dispatch_async(gridQueue) {
+            let grid = self.grid.setActive(cell.alive, atLocation: cell.coordinate)
+            self.grid = grid
+            
+            dispatch_async(dispatch_get_main_queue()){
+                let alive = cell.alive
+                let start: CGFloat = alive ? 0 : 1
+                let end: CGFloat = alive ? 1 : 0
+                let duration: CFTimeInterval = alive ? 0.2 : 0.1
+                let config = AnimationConfiguration(startValue: start, endValue: end, duration: duration)
+                Animator.addAnimationForViews([cell], configuration: config)
+            }
+        }
+    }
+}
+
+// Shake
+extension ViewController {
     override func canBecomeFirstResponder() -> Bool {
-      return true
+        return true
     }
-  
-  override func motionEnded(motion: UIEventSubtype, withEvent event: UIEvent) {
-    if motion == .MotionShake {
-      grid = emptyGrid(numberOfRows,numberOfColumns)
-      updateGrid()
-      stop()
+    
+    override func motionEnded(motion: UIEventSubtype, withEvent event: UIEvent) {
+        if motion == .MotionShake {
+            grid = emptyGrid(numberOfRows,numberOfColumns)
+            updateGrid()
+            stop()
+        }
     }
-  }
-  
 }
 


### PR DESCRIPTION
UI en animaties gerefactored.

Er is nu per kloktik 1 animatie voor alle infadende cells en 1 animatie voor alle uitfadende cells.

Als een view animatie niet klaar is voordat een nieuwe animatie voor die view gestart wordt, bv doordat er op de view wordt getapt, dan wordt de view uit de oude animatie verwijderd en neemt een nieuwe animatie de huidige waarde als startwaarde. Ik heb een animatie om deze reden een identifier meegegeven die opgeslagen wordt in de animationState (enum) van de view.

Het maken van een grid gebeurt nu op een seriële queue. Met uitzondering van de eerste keer. Dan gebeurd het op de main thread.

Het zijn veel veranderingen, ook in volgorde van code. Dus het is misschien beter om de uiteindelijke code te scannen op gekke dingen dan alle wijzigingen per stuk te bekijken.
